### PR TITLE
Add hamburger navigation for mobile header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,1616 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+:root {
+  --brand-navy: #012b5c;
+  --brand-blue: #003f87;
+  --brand-orange: #ff7a00;
+  --brand-amber: #ffb347;
+  --brand-sky: #e6f0ff;
+  --brand-ink: #0b1739;
+  --text-muted: #4a5772;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, var(--brand-sky) 0%, #ffffff 40%, #f7f9ff 100%);
+  color: var(--brand-ink);
+}
+
+.main-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 12px 25px rgba(6, 25, 64, 0.08);
+}
+
+.header-top {
+  background: linear-gradient(90deg, var(--brand-blue) 0%, var(--brand-navy) 100%);
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  padding: 0.5rem clamp(1.5rem, 4vw, 6rem);
+  font-size: 0.85rem;
+  font-weight: 600;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.header-top span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-width: min(320px, 100%);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.top-links {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.header-top a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.header-top a:hover {
+  text-decoration: underline;
+}
+
+.header-main {
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem clamp(1.5rem, 4vw, 6rem);
+  box-shadow: inset 0 -1px 0 rgba(1, 43, 92, 0.08);
+  position: relative;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--brand-ink);
+}
+
+.brand-logo {
+  width: clamp(120px, 14vw, 180px);
+  height: auto;
+}
+
+.header-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+}
+
+.main-nav {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  flex: 1 1 auto;
+}
+
+.main-nav button {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--brand-ink);
+  padding: 0.55rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.main-nav button:hover {
+  background: rgba(0, 63, 135, 0.08);
+  border-color: rgba(1, 43, 92, 0.16);
+}
+
+.main-nav button.active {
+  background: var(--brand-orange);
+  border-color: var(--brand-orange);
+  color: #ffffff;
+}
+
+.nav-count {
+  margin-left: 0.5rem;
+  background: #ffffff;
+  color: var(--brand-orange);
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+}
+
+.header-cta {
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.4rem;
+  background: var(--brand-orange);
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 12px 25px rgba(255, 122, 0, 0.25);
+}
+
+.header-cta:hover {
+  background: #ff8e24;
+}
+
+.cart-trigger {
+  border-radius: 999px;
+  border: 1px solid rgba(1, 43, 92, 0.18);
+  padding: 0.6rem 1.2rem;
+  background: rgba(0, 63, 135, 0.06);
+  color: var(--brand-ink);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cart-trigger.active {
+  border-color: var(--brand-orange);
+}
+
+.cart-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  background: var(--brand-orange);
+  color: #ffffff;
+  font-size: 0.75rem;
+}
+
+.mobile-menu-toggle {
+  display: none;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(1, 43, 92, 0.14);
+  background: #ffffff;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mobile-menu-toggle span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--brand-ink);
+  border-radius: 999px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.mobile-menu-toggle.open {
+  border-color: var(--brand-orange);
+  box-shadow: 0 12px 24px rgba(255, 122, 0, 0.18);
+}
+
+.mobile-menu-toggle.open span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.mobile-menu-toggle.open span:nth-child(2) {
+  opacity: 0;
+}
+
+.mobile-menu-toggle.open span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.mobile-nav-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 23, 57, 0.35);
+  border: none;
+  padding: 0;
+  margin: 0;
+  z-index: 80;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.content-area {
+  flex: 1;
+  padding: clamp(1.5rem, 4vw, 4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.home-view {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+@media (max-width: 960px) {
+  .header-navigation {
+    gap: 1rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .header-actions {
+    flex: 1 1 280px;
+    justify-content: flex-end;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (max-width: 900px) {
+  .header-main {
+    padding: 0.85rem clamp(1.25rem, 6vw, 3rem);
+    gap: 1rem;
+  }
+
+  .mobile-menu-toggle {
+    display: inline-flex;
+  }
+
+  .header-navigation {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    background: #ffffff;
+    border-radius: 0 0 1.5rem 1.5rem;
+    box-shadow: 0 18px 36px rgba(6, 25, 64, 0.12);
+    padding: 1.5rem clamp(1.25rem, 8vw, 2.75rem);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-12px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 110;
+  }
+
+  .header-main.nav-open .header-navigation {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .main-nav {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .main-nav button {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0.65rem 1.1rem;
+  }
+
+  .header-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .header-cta,
+  .cart-trigger {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .brand-logo {
+    max-width: 150px;
+  }
+
+  .mobile-nav-backdrop.visible {
+    display: block;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .header-top {
+    flex-direction: column;
+    padding: 0.75rem clamp(1.25rem, 8vw, 2.75rem);
   }
 }
 
-.card {
-  padding: 2em;
+@media (max-width: 520px) {
+  .header-top {
+    gap: 0.35rem;
+    font-size: 0.78rem;
+  }
+
+  .header-top .top-links {
+    gap: 0.85rem;
+  }
+
+  .brand-logo {
+    max-width: 132px;
+  }
 }
 
-.read-the-docs {
-  color: #888;
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+  background: linear-gradient(135deg, rgba(0, 63, 135, 0.08) 0%, rgba(255, 122, 0, 0.12) 100%);
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  margin: 0;
+  color: var(--brand-ink);
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--brand-orange);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero-actions button {
+  border-radius: 999px;
+  padding-inline: 1.75rem;
+  padding-block: 0.85rem;
+  font-weight: 600;
+  border: none;
+  background: var(--brand-orange);
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(255, 122, 0, 0.28);
+}
+
+.hero-actions button.secondary {
+  background: transparent;
+  border: 1px solid var(--brand-ink);
+  color: var(--brand-ink);
+  box-shadow: none;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.hero-metrics dt {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--brand-ink);
+  margin: 0;
+}
+
+.hero-metrics dd {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.hero-showcase {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.hero-image {
+  border-radius: 1.5rem;
+  min-height: 220px;
+  background: linear-gradient(160deg, rgba(1, 43, 92, 0.28) 0%, rgba(255, 122, 0, 0.2) 75%),
+    url('https://images.unsplash.com/photo-1582719478250-7615fb613b6b?auto=format&fit=crop&w=960&q=80')
+      center/cover;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.1), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.12), transparent 45%);
+}
+
+.hero-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 35px rgba(1, 43, 92, 0.12);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-card button {
+  justify-self: flex-start;
+  border-radius: 999px;
+  border: none;
+  background: var(--brand-blue);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+}
+
+.commitment {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 2rem;
+  border: 1px solid rgba(3, 18, 38, 0.08);
+  box-shadow: 0 12px 30px rgba(3, 18, 38, 0.06);
+}
+
+.commitment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.commitment-grid article {
+  background: #f8fafc;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(3, 18, 38, 0.05);
+}
+
+.commitment-grid span {
+  font-size: 2rem;
+}
+
+.showcase-grid {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 2rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+  box-shadow: 0 20px 35px rgba(1, 43, 92, 0.08);
+}
+
+.showcase-grid header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 540px;
+}
+
+.showcase-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.showcase-cards article {
+  background: #f5f8ff;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  display: grid;
+  gap: 1.25rem;
+  border: 1px solid rgba(0, 63, 135, 0.1);
+  box-shadow: 0 18px 35px rgba(1, 43, 92, 0.12);
+}
+
+.showcase-cards img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+}
+
+.showcase-cards article div {
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.showcase-metric {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 122, 0, 0.12);
+  color: var(--brand-orange);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.featured-categories {
+  background: linear-gradient(135deg, var(--brand-blue) 0%, var(--brand-navy) 100%);
+  color: #ffffff;
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 2rem;
+}
+
+.featured-copy {
+  max-width: 520px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.category-card {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.category-card button {
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: var(--brand-orange);
+  color: #ffffff;
+  font-weight: 600;
+  border: none;
+}
+
+.brands-strip {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+}
+
+.brands-strip ul {
+  list-style: none;
+  display: flex;
+  gap: 1.75rem;
+  flex-wrap: wrap;
+  padding: 0;
+  margin: 0;
+  font-weight: 600;
+  color: var(--brand-blue);
+}
+
+.project-gallery {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 2rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+  box-shadow: 0 16px 30px rgba(1, 43, 92, 0.08);
+}
+
+.project-gallery header {
+  max-width: 560px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-grid article {
+  background: #f7f9ff;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  display: grid;
+  gap: 0;
+  border: 1px solid rgba(0, 63, 135, 0.1);
+}
+
+.project-grid img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+}
+
+.project-grid article div {
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.project-grid h3 {
+  margin: 0;
+  color: var(--brand-ink);
+}
+
+.project-grid p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.cta-banner {
+  background: linear-gradient(135deg, var(--brand-orange) 0%, var(--brand-amber) 100%);
+  color: var(--brand-ink);
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.cta-banner button {
+  border-radius: 999px;
+  border: none;
+  background: var(--brand-navy);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.75rem 1.8rem;
+  box-shadow: 0 12px 24px rgba(1, 43, 92, 0.18);
+}
+
+.catalog-view {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(240px, 280px) 1fr;
+}
+
+.filters {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border: 1px solid rgba(1, 43, 92, 0.1);
+  box-shadow: 0 15px 30px rgba(1, 43, 92, 0.08);
+}
+
+.filters input,
+.filters button,
+.filters a {
+  font-family: inherit;
+}
+
+.filters input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(1, 43, 92, 0.16);
+  background: #f4f7ff;
+}
+
+.filter-group ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.filter-group button {
+  width: 100%;
+  text-align: left;
+  padding: 0.65rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid transparent;
+  background: #f1f4fa;
+  color: var(--brand-ink);
+  font-weight: 500;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.filter-group button:hover,
+.filter-group button.active {
+  background: rgba(0, 63, 135, 0.1);
+  border-color: var(--brand-blue);
+  color: var(--brand-blue);
+}
+
+.filter-tags {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.filter-tags li {
+  background: rgba(1, 43, 92, 0.06);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--brand-navy);
+  font-weight: 600;
+  text-align: center;
+}
+
+.filter-cta {
+  background: var(--brand-navy);
+  color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.filter-cta a {
+  color: var(--brand-amber);
+  font-weight: 600;
+}
+
+.filter-insight {
+  background: rgba(0, 63, 135, 0.08);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid rgba(0, 63, 135, 0.12);
+}
+
+.filter-insight h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--brand-navy);
+}
+
+.filter-insight ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.25rem;
+  color: var(--brand-ink);
+  font-size: 0.9rem;
+}
+
+.product-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.catalog-header {
+  background: linear-gradient(135deg, rgba(0, 63, 135, 0.08), rgba(255, 122, 0, 0.12));
+  border-radius: 1.5rem;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  border: 1px solid rgba(1, 43, 92, 0.12);
+}
+
+.catalog-header h2 {
+  margin: 0;
+  color: var(--brand-navy);
+}
+
+.catalog-header p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.catalog-stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.catalog-stats div {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(1, 43, 92, 0.08);
+}
+
+.catalog-stats dt {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--brand-blue);
+  margin: 0 0 0.3rem;
+}
+
+.catalog-stats dd {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--brand-ink);
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.product-card {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+  position: relative;
+  box-shadow: 0 12px 24px rgba(1, 43, 92, 0.08);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 30px rgba(1, 43, 92, 0.12);
+}
+
+.product-card:focus-visible {
+  outline: 3px solid var(--brand-blue);
+  outline-offset: 4px;
+}
+
+.product-media {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+  aspect-ratio: 4 / 3;
+  background: #eef3ff;
+}
+
+.product-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.product-badge {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  background: var(--brand-navy);
+  color: #ffffff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.product-content {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.product-card h3 {
+  margin: 0;
+  color: var(--brand-ink);
+}
+
+.product-card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.product-brand {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--brand-blue);
+}
+
+.product-feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--brand-ink);
+}
+
+.product-feature-list li::before {
+  content: '•';
+  color: var(--brand-orange);
+  margin-right: 0.4rem;
+}
+
+.product-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.product-price {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--brand-blue);
+}
+
+.product-unit {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.product-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.product-actions button {
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: var(--brand-orange);
+  color: #ffffff;
+  border: none;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(255, 122, 0, 0.2);
+}
+
+.product-actions .ghost {
+  background: rgba(1, 43, 92, 0.08);
+  color: var(--brand-navy);
+  box-shadow: none;
+}
+
+.empty-state {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  text-align: center;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+}
+
+.product-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.product-detail-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(1, 43, 92, 0.6);
+  border: none;
+  cursor: pointer;
+}
+
+.product-detail-dialog {
+  position: relative;
+  background: #ffffff;
+  border-radius: 1.5rem;
+  max-width: min(1080px, 96vw);
+  width: 100%;
+  max-height: min(90vh, 960px);
+  overflow: auto;
+  padding: 2.5rem;
+  display: grid;
+  gap: 2rem;
+  box-shadow: 0 35px 60px rgba(1, 43, 92, 0.25);
+}
+
+.product-detail-dialog::-webkit-scrollbar {
+  width: 10px;
+}
+
+.product-detail-dialog::-webkit-scrollbar-thumb {
+  background: rgba(1, 43, 92, 0.2);
+  border-radius: 999px;
+}
+
+.product-detail-header {
+  display: grid;
+  gap: 0.4rem;
+  align-items: start;
+}
+
+.detail-brand {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--brand-blue);
+}
+
+.detail-meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.detail-close {
+  justify-self: end;
+  background: transparent;
+  border: 1px solid rgba(1, 43, 92, 0.2);
+  border-radius: 999px;
+  padding: 0.45rem 1.4rem;
+  color: var(--brand-navy);
+  font-weight: 600;
+}
+
+.product-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(320px, 1.2fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.detail-gallery {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-main-image {
+  border-radius: 1.25rem;
+  overflow: hidden;
+  background: #f4f7ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 4 / 3;
+}
+
+.detail-main-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.detail-thumbnails {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.detail-thumbnails button {
+  border: 2px solid transparent;
+  border-radius: 0.85rem;
+  padding: 0;
+  background: transparent;
+  width: 72px;
+  height: 72px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.detail-thumbnails button img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.detail-thumbnails button.active {
+  border-color: var(--brand-orange);
+}
+
+.detail-info {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.detail-description {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--brand-ink);
+}
+
+.detail-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.detail-highlights article {
+  background: #f3f6ff;
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-highlights h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--brand-blue);
+}
+
+.detail-highlights p {
+  margin: 0;
+  color: var(--brand-navy);
+}
+
+.detail-feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+  color: var(--brand-ink);
+}
+
+.detail-feature-list li::before {
+  content: '✔';
+  color: var(--brand-orange);
+  margin-right: 0.4rem;
+}
+
+.detail-specs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.detail-specs div {
+  background: #f7f9ff;
+  border-radius: 1rem;
+  padding: 0.9rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-specs dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--brand-blue);
+}
+
+.detail-specs dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--brand-ink);
+}
+
+.detail-downloads {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-downloads a {
+  color: var(--brand-blue);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.detail-downloads a::after {
+  content: '↗';
+  font-size: 0.85rem;
+}
+
+.detail-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.detail-footer button {
+  border-radius: 999px;
+  padding: 0.7rem 1.8rem;
+  background: var(--brand-orange);
+  color: #ffffff;
+  border: none;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(255, 122, 0, 0.25);
+}
+
+.cart-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.cart-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.cart-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+}
+
+.cart-actions {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: end;
+}
+
+.cart-actions input {
+  width: 80px;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(1, 43, 92, 0.16);
+  background: #f4f7ff;
+}
+
+.cart-price {
+  font-weight: 700;
+  color: var(--brand-blue);
+}
+
+.cart-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--brand-navy);
+  color: #ffffff;
+  border-radius: 1.25rem;
+  padding: 1.5rem 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.cart-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cart-buttons .secondary {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #ffffff;
+}
+
+.cart-buttons .primary {
+  border-radius: 999px;
+  padding: 0.75rem 1.8rem;
+  background: var(--brand-orange);
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.contact-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.contact-form,
+.contact-info {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  border: 1px solid rgba(1, 43, 92, 0.08);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-form input,
+.contact-form textarea,
+.contact-form button {
+  font-family: inherit;
+}
+
+.contact-form input,
+.contact-form textarea {
+  border-radius: 0.8rem;
+  border: 1px solid rgba(1, 43, 92, 0.16);
+  padding: 0.75rem 1rem;
+  background: #f4f7ff;
+}
+
+.contact-form button {
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0.8rem 1.6rem;
+  background: var(--brand-blue);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.contact-info ul {
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.site-footer {
+  background: linear-gradient(180deg, var(--brand-navy) 0%, #011736 100%);
+  color: #ffffff;
+  margin-top: 4rem;
+}
+
+.footer-main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 6rem);
+}
+
+.footer-column {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.footer-brand {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand img {
+  width: clamp(150px, 18vw, 210px);
+  height: auto;
+}
+
+.footer-tagline {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 0.3rem;
+  display: block;
+}
+
+.footer-column h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--brand-amber);
+}
+
+.footer-column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-column button {
+  text-align: left;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+
+.footer-column button:hover,
+.footer-column a:hover {
+  color: var(--brand-amber);
+}
+
+.footer-column a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.footer-form input {
+  flex: 1;
+  min-width: 180px;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
+.footer-form button {
+  border-radius: 0.75rem;
+  border: none;
+  background: var(--brand-orange);
+  color: #ffffff;
+  font-weight: 700;
+  padding: 0.65rem 1.25rem;
+  box-shadow: 0 8px 18px rgba(255, 122, 0, 0.2);
+}
+
+.footer-bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1rem clamp(1.5rem, 4vw, 6rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.footer-socials {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer-socials a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-socials a:hover {
+  color: var(--brand-amber);
+}
+
+.whatsapp-fab {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background: #25d366;
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.85rem 1.5rem;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 15px 25px rgba(37, 211, 102, 0.4);
+}
+
+@media (max-width: 900px) {
+  .header-main {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .catalog-view {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    order: -1;
+  }
+
+  .product-detail-dialog {
+    padding: 2rem;
+    max-height: 90vh;
+  }
+
+  .product-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cart-list li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cart-actions {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .cart-actions input {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero-actions button,
+  .category-card button,
+  .product-actions button,
+  .detail-footer button,
+  .contact-form button,
+  .hero-card button,
+  .cta-banner button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .cta-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .product-detail-overlay {
+    padding: 1rem;
+  }
+
+  .product-detail-dialog {
+    padding: 1.75rem;
+  }
+
+  .detail-thumbnails button {
+    width: 60px;
+    height: 60px;
+  }
+
+  .detail-footer {
+    align-items: stretch;
+  }
+
+  .product-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .product-actions button {
+    flex: 1 1 100%;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,1371 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
+const demoProducts = [
+  {
+    id: 1,
+    name: 'Taladro Percutor 13mm',
+    brand: 'Bosch Professional',
+    sku: 'GBM13-2RE',
+    description:
+      'Taladro eléctrico de 750W con velocidad variable y sistema de percusión para concreto, metal y madera.',
+    category: 'Electricidad',
+    price: 159.99,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1527358040820-09d9d5c4725f?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1582719478250-588e25a58d1d?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1582719478250-4dd1c92f9ae1?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'En stock inmediato',
+    leadTime: 'Despacho en 24h para Lima Metropolitana',
+    features: [
+      'Motor de 750W para trabajos continuos',
+      'Portabrocas automático de 13mm con bloqueo rápido',
+      'Selector de velocidad y reversa para mayor control',
+    ],
+    specs: {
+      Potencia: '750 W',
+      Velocidad: '0-3,000 rpm',
+      Percusión: '48,000 ipm',
+      Peso: '1.8 kg',
+    },
+    downloads: [
+      {
+        label: 'Ficha técnica Bosch',
+        url: 'https://www.bosch-pt.com/wcsstore/BoschProfessionalB2BStorefrontAssetStore/ocsmedia/optimized/large/678/GBH_2-26_DRE.pdf',
+      },
+      {
+        label: 'Manual de usuario',
+        url: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Juego de Brocas Multiuso 15 piezas',
+    brand: 'DeWalt',
+    sku: 'DW1354',
+    description:
+      'Set con recubrimiento de titanio y estuche magnético para perforaciones en metal, madera y PVC.',
+    category: 'Accesorios',
+    price: 42.5,
+    unit: 'juego',
+    image:
+      'https://images.unsplash.com/photo-1515573990-aee0a0ee3c8d?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1503389152951-9f343605f61e?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1594381898411-846e7d193883?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Envío en 48h',
+    leadTime: 'Stock en almacén Ate y Callao',
+    features: [
+      'Puntas afiladas para perforación rápida',
+      'Recubrimiento de titanio de larga duración',
+      'Estuche magnético con clip para cinturón',
+    ],
+    specs: {
+      Presentación: '15 piezas',
+      Material: 'Acero HSS recubierto',
+      Diámetros: '1.5 mm a 10 mm',
+      Peso: '0.6 kg',
+    },
+    downloads: [
+      {
+        label: 'Catálogo DeWalt accesorios',
+        url: 'https://www.dewalt.com/sites/default/files/2022-03/DEWALT-Access-oryCatalog.pdf',
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: 'Martillo Carpintero 20oz',
+    brand: 'Truper',
+    sku: 'MART-20F',
+    description: 'Mango de fibra de vidrio con grip ergonómico anti vibraciones.',
+    category: 'Manuales',
+    price: 18.75,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1517348025100-4d1d6308b0a3?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1506084868230-bb9d95c24759?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Disponible para retiro en tienda',
+    leadTime: 'Entrega a provincia en 72h',
+    features: [
+      'Cabeza pulida y balanceada',
+      'Zona magnética para fijar clavos',
+      'Garantía de 10 años contra defectos',
+    ],
+    specs: {
+      Peso: '0.9 kg',
+      Longitud: '33 cm',
+      Material: 'Acero forjado / fibra de vidrio',
+      Garantía: '10 años',
+    },
+    downloads: [
+      {
+        label: 'Ficha técnica Truper',
+        url: 'https://www.truper.com.mx/Documentos/000020877.pdf',
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'Llave Stillson 14"',
+    brand: 'Ridgid',
+    sku: '31020',
+    description: 'Cuerpo de hierro dúctil y mordazas templadas para tuberías hasta 2".',
+    category: 'Plomería',
+    price: 36.95,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1616628182500-94e3326d6c7c?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1597003037667-359b8d4a239b?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1582719478442-7aa7d61b52f9?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Stock permanente',
+    leadTime: 'Cobertura nacional con operadores aliados',
+    features: [
+      'Ajuste rápido gracias a rosca trapezoidal',
+      'Mordazas reemplazables y dentado agresivo',
+      'Estructura de hierro dúctil resistente a impactos',
+    ],
+    specs: {
+      Longitud: '355 mm',
+      Apertura: 'Hasta 60 mm',
+      Material: 'Hierro dúctil y acero aleado',
+      Peso: '1.5 kg',
+    },
+    downloads: [
+      {
+        label: 'Catálogo Ridgid tuberías',
+        url: 'https://cdn2.ridgid.com/resources/media?key=ridgid_pipe_wrenches_catalog.pdf',
+      },
+    ],
+  },
+  {
+    id: 5,
+    name: 'Escalera Multiuso 12 pasos',
+    brand: 'Werner',
+    sku: 'MT-17',
+    description:
+      'Estructura de aluminio reforzado con 24 configuraciones y certificación ANSI tipo IA.',
+    category: 'Equipos',
+    price: 229.0,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1569428034239-5c76dc1123cf?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1503389152951-9f343605f61e?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1507668077129-56e32842fceb?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Bajo pedido 24h',
+    leadTime: 'Despachos programados a obra con coordinación previa',
+    features: [
+      '24 configuraciones entre escalera recta y tijera',
+      'Capacidad de carga de 150 kg certificada',
+      'Bisagras con bloqueo automático y peldaños antideslizantes',
+    ],
+    specs: {
+      'Altura máxima': '5.2 m',
+      Material: 'Aluminio 6005-T5',
+      Certificación: 'ANSI IA / OSHA',
+      Peso: '20.4 kg',
+    },
+    downloads: [
+      {
+        label: 'Guía de uso Werner',
+        url: 'https://www.wernerco.com/us/-/media/Project/OneWerner/Documents/ProductLiterature/Multi-Position-Ladder-Manual.pdf',
+      },
+    ],
+  },
+  {
+    id: 6,
+    name: 'Disco Corte Metal 7"',
+    brand: '3M Cubitron II',
+    sku: '66514',
+    description: 'Disco abrasivo premium para cortes limpios en acero al carbono e inoxidable.',
+    category: 'Accesorios',
+    price: 6.8,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1516116216624-53e697fedbea?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Stock alto',
+    leadTime: 'Disponibilidad inmediata en Lima y provincias',
+    features: [
+      'Abrasivo cerámico de autoafilado',
+      'Reduce la generación de chispas y rebabas',
+      'Duración hasta 2x frente a discos tradicionales',
+    ],
+    specs: {
+      Diámetro: '180 mm',
+      Espesor: '1.6 mm',
+      'RPM máx.': '8,600',
+      Aplicación: 'Corte en frío de acero',
+    },
+    downloads: [
+      {
+        label: 'Ficha Cubitron II',
+        url: 'https://multimedia.3m.com/mws/media/1549904O/cubitron-ii-cut-off-wheels-brochure.pdf',
+      },
+    ],
+  },
+  {
+    id: 7,
+    name: 'Guantes Nitrilo Premium',
+    brand: 'Ansell',
+    sku: '37-175',
+    description: 'Protección contra químicos e hidrocarburos con palma texturizada.',
+    category: 'Seguridad',
+    price: 5.6,
+    unit: 'par',
+    image:
+      'https://images.unsplash.com/photo-1619972828020-2c1e1d4b53ef?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1582719478250-4a46f608bae2?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1582719478250-ccb2e9fe09d6?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Stock por tallas S-M-L',
+    leadTime: 'Reabastecimiento semanal',
+    features: [
+      'Nitrilo de alta resistencia a químicos',
+      'Acabado arenoso para máximo agarre',
+      'Forro de algodón flocado interior',
+    ],
+    specs: {
+      Largo: '330 mm',
+      Espesor: '0.38 mm',
+      Norma: 'EN 374, EN 388',
+      Color: 'Verde',
+    },
+    downloads: [
+      {
+        label: 'Hoja de seguridad Ansell',
+        url: 'https://assets.ansell.com/documents/chemical-gloves/solvex-37-175-PI-es.pdf',
+      },
+    ],
+  },
+  {
+    id: 8,
+    name: 'Kit Instalación Sanitarios',
+    brand: 'Vainsa',
+    sku: 'KIT-SANI-01',
+    description:
+      'Set completo con codos, sellos, teflón y válvula de cierre para proyectos residenciales.',
+    category: 'Plomería',
+    price: 64.9,
+    unit: 'kit',
+    image:
+      'https://images.unsplash.com/photo-1582719478250-04fd7c3d0a3d?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Listo para despacho',
+    leadTime: 'Envíos en 48h a Lima y provincias principales',
+    features: [
+      'Incluye válvula de esfera y llave de paso cromada',
+      'Sellos y empaques de silicona grado sanitario',
+      'Manual ilustrado paso a paso',
+    ],
+    specs: {
+      Componentes: '18 piezas',
+      Materiales: 'PVC, latón cromado, PTFE',
+      Uso: 'Instalaciones sanitarias domésticas',
+      Garantía: '2 años',
+    },
+    downloads: [
+      {
+        label: 'Guía de instalación',
+        url: 'https://www.orimi.com/pdf-test.pdf',
+      },
+    ],
+  },
+  {
+    id: 9,
+    name: 'Pintura Epóxica Bicomponente',
+    brand: 'Sika',
+    sku: 'Sikafloor-263',
+    description: 'Recubrimiento epóxico autonivelante resistente a químicos y abrasión.',
+    category: 'Acabados',
+    price: 129.0,
+    unit: 'kit 20kg',
+    image:
+      'https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1507668077129-56e32842fceb?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Producción bajo pedido 72h',
+    leadTime: 'Asistencia técnica en obra incluida',
+    features: [
+      'Acabado autonivelante de alto brillo',
+      'Excelente resistencia química y mecánica',
+      'Compatible con sistemas antideslizantes',
+    ],
+    specs: {
+      Rendimiento: '0.7 kg/m² por mm',
+      Curado: '48h tránsito peatonal',
+      Acabado: 'Brillante',
+      Colores: 'Carta Sika Industrial',
+    },
+    downloads: [
+      {
+        label: 'Ficha técnica Sika',
+        url: 'https://per.sika.com/dms/getdocument.get/94ab14da-e5d0-3c96-9116-73cf17a4c0cb/sikafloor-263-sl.pdf',
+      },
+      {
+        label: 'Guía de preparación de superficies',
+        url: 'https://per.sika.com/dms/getdocument.get/eb47779f-6957-3f58-9109-4ff57c939728/preparacion-superficies.pdf',
+      },
+    ],
+  },
+  {
+    id: 10,
+    name: 'Soldadora Inverter 200A',
+    brand: 'Lincoln Electric',
+    sku: 'Invertec 170S',
+    description: 'Equipo portátil de soldadura SMAW/GTAW con tecnología IGBT y ventilación inteligente.',
+    category: 'Soldadura',
+    price: 499.0,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1582719478250-1df4c08eddf4?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1516116216624-53e697fedbea?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Incluye capacitación inicial',
+    leadTime: 'Entrega en 72h con instalación',
+    features: [
+      'Tecnología IGBT de alto desempeño',
+      'Protección contra sobrecarga y polvo',
+      'Compatible con generadores y variaciones de voltaje',
+    ],
+    specs: {
+      Corriente: '10-170 A',
+      Alimentación: '220 V monofásica',
+      Peso: '9.5 kg',
+      Garantía: '3 años',
+    },
+    downloads: [
+      {
+        label: 'Brochure Lincoln Electric',
+        url: 'https://assets.lincolnelectric.com/assets/EU/DM/CE/EN-170S.pdf',
+      },
+    ],
+  },
+  {
+    id: 11,
+    name: 'Detector Láser Multilínea',
+    brand: 'Stanley',
+    sku: 'STHT77594',
+    description: 'Nivel láser de líneas 360° con alcance de 25 metros y auto nivelación.',
+    category: 'Medición',
+    price: 215.0,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1503389152951-9f343605f61e?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Incluye trípode y estuche rígido',
+    leadTime: 'Retiro en tienda el mismo día',
+    features: [
+      'Rango de trabajo de 25 m (50 m con detector)',
+      'Batería recargable con autonomía de 10h',
+      'Base magnética giratoria 360°',
+    ],
+    specs: {
+      Precisión: '±3 mm a 10 m',
+      Protección: 'IP54',
+      Batería: 'Li-ion 4 Ah',
+      Peso: '0.9 kg',
+    },
+    downloads: [
+      {
+        label: 'Manual Stanley',
+        url: 'https://www.stanleytools.com/sites/stanleytools/files/STHT77594_manual.pdf',
+      },
+    ],
+  },
+  {
+    id: 12,
+    name: 'Compresor de Aire 3HP 50L',
+    brand: 'Ingersoll Rand',
+    sku: 'SS3J5.5GH-WB',
+    description: 'Compresor lubricado para trabajos industriales ligeros con tanque de 50 litros.',
+    category: 'Neumática',
+    price: 699.0,
+    unit: 'unidad',
+    image:
+      'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=640&q=80',
+    gallery: [
+      'https://images.unsplash.com/photo-1582719478250-35a19f8ecf66?auto=format&fit=crop&w=960&q=80',
+      'https://images.unsplash.com/photo-1503389152951-9f343605f61e?auto=format&fit=crop&w=960&q=80',
+    ],
+    availability: 'Incluye puesta en marcha',
+    leadTime: 'Instalación y pruebas en 5 días',
+    features: [
+      'Capacidad de 11.8 CFM @ 90 PSI',
+      'Motor de 3 HP con protector térmico',
+      'Bomba de hierro fundido de dos etapas',
+    ],
+    specs: {
+      Tanque: '50 L',
+      'Presión máxima': '135 PSI',
+      Alimentación: '220 V monofásica',
+      Peso: '68 kg',
+    },
+    downloads: [
+      {
+        label: 'Ficha técnica Ingersoll Rand',
+        url: 'https://www.ingersollrand.com/bin/productdocs/supportmaterials/air-compressor-ss3-manual.pdf',
+      },
+      {
+        label: 'Checklist de mantenimiento',
+        url: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+      },
+    ],
+  },
+]
+
+const solutionShowcase = [
+  {
+    title: 'Ferretería industrial',
+    description:
+      'Suministro de herramientas eléctricas y neumáticas para obras de gran escala, con trazabilidad de lote y soporte técnico.',
+    image:
+      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=720&q=80',
+    metric: 'Catálogo +850 SKUs',
+  },
+  {
+    title: 'Infraestructura hidráulica',
+    description:
+      'Tubos, válvulas y accesorios certificados para plantas de tratamiento y proyectos de saneamiento.',
+    image:
+      'https://images.unsplash.com/photo-1521207418485-99c705420785?auto=format&fit=crop&w=720&q=80',
+    metric: 'Cobertura 12 ciudades',
+  },
+  {
+    title: 'Seguridad y EPP',
+    description:
+      'Inventario permanente de equipos de protección personal para minería, petróleo y construcción.',
+    image:
+      'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=720&q=80',
+    metric: 'Despachos en 48h',
+  },
+]
+
+const projectHighlights = [
+  {
+    title: 'Modernización de planta cementera',
+    description:
+      'Abastecimos líneas de potencia, anclajes y sistemas de seguridad con entregas programadas en obra.',
+    image:
+      'https://images.unsplash.com/photo-1582719478250-9ff3fe5cf29c?auto=format&fit=crop&w=960&q=80',
+  },
+  {
+    title: 'Red de gas natural Lima Norte',
+    description:
+      'Coordinamos el suministro de herramientas de corte, válvulas y tuberías para más de 30 cuadrillas simultáneas.',
+    image:
+      'https://images.unsplash.com/photo-1582719478250-c4b7b1b2b00b?auto=format&fit=crop&w=960&q=80',
+  },
+]
+
+const views = {
+  home: 'Inicio',
+  catalog: 'Catálogo',
+  cart: 'Cotizador',
+  contact: 'Contacto',
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [activeView, setActiveView] = useState('home')
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('Todas')
+  const [cartItems, setCartItems] = useState([])
+  const [selectedProduct, setSelectedProduct] = useState(null)
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
+
+  const categories = useMemo(
+    () => ['Todas', ...new Set(demoProducts.map((product) => product.category))],
+    [],
+  )
+
+  const filteredProducts = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase()
+
+    return demoProducts.filter((product) => {
+      const matchesCategory =
+        selectedCategory === 'Todas' || product.category === selectedCategory
+      const matchesTerm =
+        term.length === 0 ||
+        product.name.toLowerCase().includes(term) ||
+        product.description.toLowerCase().includes(term)
+
+      return matchesCategory && matchesTerm
+    })
+  }, [searchTerm, selectedCategory])
+
+  const handleViewChange = (view) => {
+    setActiveView(view)
+    setIsMobileNavOpen(false)
+  }
+
+  const addToCart = (product) => {
+    setCartItems((prev) => {
+      const existing = prev.find((item) => item.product.id === product.id)
+
+      if (existing) {
+        return prev.map((item) =>
+          item.product.id === product.id
+            ? { ...item, quantity: item.quantity + 1 }
+            : item,
+        )
+      }
+
+      return [...prev, { product, quantity: 1 }]
+    })
+    handleViewChange('cart')
+  }
+
+  const updateQuantity = (productId, quantity) => {
+    setCartItems((prev) =>
+      prev
+        .map((item) =>
+          item.product.id === productId ? { ...item, quantity } : item,
+        )
+        .filter((item) => item.quantity > 0),
+    )
+  }
+
+  const clearCart = () => setCartItems([])
+
+  const orderTotal = cartItems.reduce(
+    (total, item) => total + item.product.price * item.quantity,
+    0,
+  )
+
+  const whatsappMessage = useMemo(() => {
+    if (cartItems.length === 0) return ''
+
+    const lines = cartItems.map(
+      (item) =>
+        `• ${item.product.name} (${item.quantity} ${item.product.unit}) - $${item.product.price.toFixed(2)}`,
+    )
+
+    return encodeURIComponent(
+      `Hola, me gustaría cotizar:\n${lines.join('\n')}\nTotal estimado: $${orderTotal.toFixed(
+        2,
+      )}`,
+    )
+  }, [cartItems, orderTotal])
+
+  const cartCount = cartItems.reduce((total, item) => total + item.quantity, 0)
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
+    <div className="app-shell">
+      <header className="main-header">
+        <div className="header-top">
+          <span>Distribuidores oficiales con cobertura nacional</span>
+          <div className="top-links">
+            <a href="tel:+5115558899">Central: (01) 555-8899</a>
+            <a href="mailto:ventas@losgigantes.pe">ventas@losgigantes.pe</a>
+          </div>
+        </div>
+        <div className={`header-main${isMobileNavOpen ? ' nav-open' : ''}`}>
+          <div
+            className="brand"
+            onClick={() => handleViewChange('home')}
+            onKeyDown={(event) =>
+              event.key === 'Enter' && handleViewChange('home')
+            }
+            role="button"
+            tabIndex={0}
+          >
+            <img
+              src="https://losgigantes.sistinfo.com/empresa/imagenes/brand_logo.png"
+              alt="Logo de Los Gigantes"
+              className="brand-logo"
+            />
+          </div>
+          <button
+            type="button"
+            className={`mobile-menu-toggle${isMobileNavOpen ? ' open' : ''}`}
+            aria-label={
+              isMobileNavOpen
+                ? 'Cerrar menú de navegación'
+                : 'Abrir menú de navegación'
+            }
+            aria-controls="primary-navigation"
+            aria-expanded={isMobileNavOpen}
+            onClick={() => setIsMobileNavOpen((prev) => !prev)}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+          <div className="header-navigation" id="primary-navigation">
+            <nav className="main-nav">
+              {Object.entries(views).map(([key, label]) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={key === activeView ? 'active' : ''}
+                  onClick={() => handleViewChange(key)}
+                >
+                  {label}
+                  {key === 'cart' && cartCount > 0 && (
+                    <span className="nav-count">{cartCount}</span>
+                  )}
+                </button>
+              ))}
+            </nav>
+            <div className="header-actions">
+              <button
+                type="button"
+                className="header-cta"
+                onClick={() => handleViewChange('contact')}
+              >
+                Contacta a un asesor
+              </button>
+              <button
+                type="button"
+                className={`cart-trigger${
+                  activeView === 'cart' ? ' active' : ''
+                }`}
+                onClick={() => handleViewChange('cart')}
+              >
+                Mi cotización
+                {cartCount > 0 && <span className="cart-count">{cartCount}</span>}
+              </button>
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          className={`mobile-nav-backdrop${
+            isMobileNavOpen ? ' visible' : ''
+          }`}
+          aria-label="Cerrar menú de navegación"
+          onClick={() => setIsMobileNavOpen(false)}
+        />
+      </header>
+
+      <main className="content-area">
+        {activeView === 'home' && <Home setActiveView={handleViewChange} />}
+        {activeView === 'catalog' && (
+          <Catalog
+            products={filteredProducts}
+            addToCart={addToCart}
+            categories={categories}
+            selectedCategory={selectedCategory}
+            setSelectedCategory={setSelectedCategory}
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            onSelectProduct={setSelectedProduct}
+          />
+        )}
+        {activeView === 'cart' && (
+          <Cart
+            cartItems={cartItems}
+            updateQuantity={updateQuantity}
+            orderTotal={orderTotal}
+            whatsappMessage={whatsappMessage}
+            clearCart={clearCart}
+          />
+        )}
+        {activeView === 'contact' && <Contact />}
+      </main>
+
+      {selectedProduct && (
+        <ProductDetail
+          product={selectedProduct}
+          onClose={() => setSelectedProduct(null)}
+          addToCart={(product) => {
+            addToCart(product)
+            setSelectedProduct(null)
+          }}
+        />
+      )}
+
+      <Footer setActiveView={handleViewChange} />
+
+      <a
+        className="whatsapp-fab"
+        href={
+          whatsappMessage
+            ? `https://wa.me/51999999999?text=${whatsappMessage}`
+            : 'https://wa.me/51999999999'
+        }
+        target="_blank"
+        rel="noreferrer"
+      >
+        <span>WhatsApp</span>
+      </a>
+    </div>
+  )
+}
+
+function Home({ setActiveView }) {
+  return (
+    <section className="home-view">
+      <article className="hero">
+        <div className="hero-copy">
+          <p className="eyebrow">Ferretería mayorista y proyectos</p>
+          <h1>Soluciones profesionales para la industria, la minería y el hogar</h1>
+          <p>
+            Integrá un catálogo con filtros inteligentes, precios referenciales y un flujo de
+            cotización que llega directo a WhatsApp para acelerar tus ventas.
+          </p>
+          <div className="hero-actions">
+            <button type="button" onClick={() => setActiveView('catalog')}>
+              Explorar catálogo
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setActiveView('contact')}
+            >
+              Agendar asesoría
+            </button>
+          </div>
+          <dl className="hero-metrics">
+            <div>
+              <dt>+1,200</dt>
+              <dd>SKUs en stock inmediato</dd>
+            </div>
+            <div>
+              <dt>48h</dt>
+              <dd>Promedio de despacho en Lima</dd>
+            </div>
+            <div>
+              <dt>24/7</dt>
+              <dd>Atención para proyectos críticos</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="hero-showcase">
+          <div className="hero-image" aria-hidden="true" role="presentation" />
+          <div className="hero-card">
+            <h3>Logística de confianza</h3>
+            <p>
+              Coordinamos entregas programadas y soporte técnico con cobertura nacional.
+            </p>
+            <button type="button" onClick={() => setActiveView('catalog')}>
+              Ver líneas de producto
+            </button>
+          </div>
+        </div>
+      </article>
+
+      <section className="commitment">
+        <h2>Nuestro compromiso</h2>
+        <div className="commitment-grid">
+          <article>
+            <span role="img" aria-hidden="true">
+              🛠️
+            </span>
+            <h3>Herramientas certificadas</h3>
+            <p>Trabajamos con marcas líderes y garantías directas del fabricante.</p>
+          </article>
+          <article>
+            <span role="img" aria-hidden="true">
+              🚚
+            </span>
+            <h3>Delivery especializado</h3>
+            <p>Unidades equipadas para entregas voluminosas y seguimiento en tiempo real.</p>
+          </article>
+          <article>
+            <span role="img" aria-hidden="true">
+              🤝
+            </span>
+            <h3>Atención personalizada</h3>
+            <p>Ejecutivos comerciales dedicados a cada sector y necesidad.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="showcase-grid">
+        <header>
+          <h2>Especialidades que potenciamos</h2>
+          <p>
+            Presenta tu portafolio estratégico con imágenes de proyectos reales y datos
+            relevantes para cada vertical.
+          </p>
+        </header>
+        <div className="showcase-cards">
+          {solutionShowcase.map((item) => (
+            <article key={item.title}>
+              <img src={item.image} alt={item.title} loading="lazy" />
+              <div>
+                <span className="showcase-metric">{item.metric}</span>
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="featured-categories">
+        <div className="featured-copy">
+          <h2>Rubros destacados</h2>
+          <p>
+            Organiza tu inventario por especialidad y permite que tus clientes encuentren todo
+            en segundos.
+          </p>
+        </div>
+        <div className="category-grid">
+          {['Electricidad', 'Plomería', 'Seguridad', 'Equipos'].map((category) => (
+            <div className="category-card" key={category}>
+              <h3>{category}</h3>
+              <p>
+                Componentes seleccionados para proyectos industriales y residenciales.
+              </p>
+              <button type="button" onClick={() => setActiveView('catalog')}>
+                Ver productos
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="project-gallery">
+        <header>
+          <h2>Casos recientes</h2>
+          <p>
+            Demuestra el alcance de tu operación con ejemplos reales de sectores que confían en
+            Los Gigantes.
+          </p>
+        </header>
+        <div className="project-grid">
+          {projectHighlights.map((project) => (
+            <article key={project.title}>
+              <img src={project.image} alt={project.title} loading="lazy" />
+              <div>
+                <h3>{project.title}</h3>
+                <p>{project.description}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="brands-strip" aria-label="Marcas aliadas">
+        <p>Distribuidores autorizados de:</p>
+        <ul>
+          {['Truper', 'Stanley', 'Bosch', 'DeWalt', 'Sika', '3M'].map((brand) => (
+            <li key={brand}>{brand}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="cta-banner">
+        <div>
+          <h2>¿Listo para cotizar tu próximo proyecto?</h2>
+          <p>
+            Integra tu catálogo, define tus precios referenciales y recibe las solicitudes por
+            WhatsApp sin fricciones.
+          </p>
+        </div>
+        <button type="button" onClick={() => setActiveView('cart')}>
+          Revisar mi cotización
         </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
+      </section>
+    </section>
+  )
+}
+
+function Catalog({
+  products,
+  addToCart,
+  categories,
+  selectedCategory,
+  setSelectedCategory,
+  searchTerm,
+  setSearchTerm,
+  onSelectProduct,
+}) {
+  return (
+    <section className="catalog-view">
+      <aside className="filters">
+        <h2>Buscar productos</h2>
+        <label htmlFor="product-search" className="filter-label">
+          Palabra clave
+        </label>
+        <input
+          id="product-search"
+          type="search"
+          placeholder="Taladro, broca, escalera..."
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+        <div className="filter-group">
+          <p className="filter-label">Categorías</p>
+          <ul>
+            {categories.map((category) => (
+              <li key={category}>
+                <button
+                  type="button"
+                  className={category === selectedCategory ? 'active' : ''}
+                  onClick={() => setSelectedCategory(category)}
+                >
+                  {category}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="filter-group">
+          <p className="filter-label">Aplicaciones frecuentes</p>
+          <ul className="filter-tags">
+            {['Montaje industrial', 'Remodelación residencial', 'Minería y energía', 'Acabados'].map(
+              (tag) => (
+                <li key={tag}>
+                  <span>{tag}</span>
+                </li>
+              ),
+            )}
+          </ul>
+        </div>
+        <div className="filter-cta">
+          <p>¿Buscas algo específico?</p>
+          <a href="https://wa.me/51999999999" target="_blank" rel="noreferrer">
+            Escríbenos por WhatsApp
+          </a>
+        </div>
+        <div className="filter-insight">
+          <h3>Servicios incluidos</h3>
+          <ul>
+            <li>Asesoría técnica para selección de equipos</li>
+            <li>Coordinación logística y entrega en obra</li>
+            <li>Gestión de garantías y mantenimiento</li>
+          </ul>
+        </div>
+      </aside>
+
+      <div className="product-results">
+        <header className="catalog-header">
+          <span className="eyebrow">Catálogo profesional</span>
+          <h2>Equipos y suministros listos para tus proyectos</h2>
+          <p>
+            Explora nuestra selección de productos destacados para el MVP. Cada ficha incluye
+            datos técnicos, fotografías de referencia y descargas listas para compartir con tus
+            clientes.
+          </p>
+          <dl className="catalog-stats">
+            <div>
+              <dt>{products.length}</dt>
+              <dd>Productos filtrados actualmente</dd>
+            </div>
+            <div>
+              <dt>12 líneas</dt>
+              <dd>Inventario base en demostración</dd>
+            </div>
+            <div>
+              <dt>+30</dt>
+              <dd>Documentos descargables vinculados</dd>
+            </div>
+          </dl>
+        </header>
+
+        {products.length === 0 ? (
+          <div className="empty-state">
+            <h3>Sin coincidencias</h3>
+            <p>
+              Ajusta tu búsqueda o selecciona otra categoría para seguir explorando el catálogo.
+            </p>
+          </div>
+        ) : (
+          <div className="product-grid">
+            {products.map((product) => (
+              <article
+                className="product-card"
+                key={product.id}
+                onClick={() => onSelectProduct(product)}
+                onKeyDown={(event) => event.key === 'Enter' && onSelectProduct(product)}
+                role="button"
+                tabIndex={0}
+              >
+                <figure className="product-media">
+                  <img src={product.image} alt={product.name} loading="lazy" />
+                  <div className="product-badge">{product.category}</div>
+                </figure>
+                <div className="product-content">
+                  <span className="product-brand">{product.brand}</span>
+                  <h3>{product.name}</h3>
+                  <p>{product.description}</p>
+                  {product.features?.length > 0 && (
+                    <ul className="product-feature-list">
+                      {product.features.slice(0, 3).map((feature) => (
+                        <li key={feature}>{feature}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div className="product-footer">
+                  <div className="product-pricing">
+                    <span className="product-price">${product.price.toFixed(2)}</span>
+                    <span className="product-unit">/ {product.unit}</span>
+                  </div>
+                  <div className="product-actions">
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        addToCart(product)
+                      }}
+                    >
+                      Añadir a cotización
+                    </button>
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        onSelectProduct(product)
+                      }}
+                    >
+                      Ver detalle
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </section>
+  )
+}
+
+function ProductDetail({ product, onClose, addToCart }) {
+  const [activeImage, setActiveImage] = useState(product.gallery?.[0] ?? product.image)
+
+  const images = useMemo(() => {
+    const allImages = [product.image, ...(product.gallery ?? [])]
+    return Array.from(new Set(allImages.filter(Boolean)))
+  }, [product])
+
+  useEffect(() => {
+    setActiveImage(product.gallery?.[0] ?? product.image)
+  }, [product])
+
+  useEffect(() => {
+    document.body.style.setProperty('overflow', 'hidden')
+    return () => {
+      document.body.style.removeProperty('overflow')
+    }
+  }, [])
+
+  return (
+    <div
+      className="product-detail-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`product-detail-${product.id}`}
+    >
+      <button type="button" className="product-detail-backdrop" onClick={onClose} aria-label="Cerrar" />
+      <div className="product-detail-dialog">
+        <header className="product-detail-header">
+          <span className="detail-brand">{product.brand}</span>
+          <h2 id={`product-detail-${product.id}`}>{product.name}</h2>
+          <div className="detail-meta">
+            <span>SKU: {product.sku}</span>
+            <span>{product.category}</span>
+          </div>
+          <button type="button" className="detail-close" onClick={onClose}>
+            Cerrar
+          </button>
+        </header>
+
+        <div className="product-detail-grid">
+          <div className="detail-gallery">
+            <figure className="detail-main-image">
+              <img src={activeImage} alt={product.name} />
+            </figure>
+            {images.length > 1 && (
+              <ul className="detail-thumbnails">
+                {images.map((image) => (
+                  <li key={image}>
+                    <button
+                      type="button"
+                      className={image === activeImage ? 'active' : ''}
+                      onClick={() => setActiveImage(image)}
+                    >
+                      <img src={image} alt={`${product.name} referencia`} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="detail-info">
+            <p className="detail-description">{product.description}</p>
+            <div className="detail-highlights">
+              <article>
+                <h3>Disponibilidad</h3>
+                <p>{product.availability}</p>
+              </article>
+              <article>
+                <h3>Lead time</h3>
+                <p>{product.leadTime}</p>
+              </article>
+            </div>
+
+            {product.features?.length > 0 && (
+              <section>
+                <h3>Beneficios clave</h3>
+                <ul className="detail-feature-list">
+                  {product.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {product.specs && (
+              <section>
+                <h3>Especificaciones técnicas</h3>
+                <dl className="detail-specs">
+                  {Object.entries(product.specs).map(([label, value]) => (
+                    <div key={label}>
+                      <dt>{label}</dt>
+                      <dd>{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            )}
+
+            {product.downloads?.length > 0 && (
+              <section>
+                <h3>Descargables</h3>
+                <ul className="detail-downloads">
+                  {product.downloads.map((item) => (
+                    <li key={item.url}>
+                      <a href={item.url} target="_blank" rel="noreferrer">
+                        {item.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <footer className="detail-footer">
+              <div>
+                <span className="product-price">${product.price.toFixed(2)}</span>
+                <span className="product-unit">/ {product.unit}</span>
+              </div>
+              <button type="button" onClick={() => addToCart(product)}>
+                Agregar a cotización
+              </button>
+            </footer>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Cart({ cartItems, updateQuantity, orderTotal, whatsappMessage, clearCart }) {
+  return (
+    <section className="cart-view">
+      <header>
+        <h2>Resumen de cotización</h2>
+        <p>
+          Ajusta cantidades y envía la selección completa directamente a nuestro equipo de
+          ventas.
+        </p>
+      </header>
+
+      {cartItems.length === 0 ? (
+        <div className="empty-state">
+          <h3>Tu carrito está vacío</h3>
+          <p>Explora el catálogo y añade productos para armar tu cotización.</p>
+        </div>
+      ) : (
+        <>
+          <ul className="cart-list">
+            {cartItems.map((item) => (
+              <li key={item.product.id}>
+                <div>
+                  <h3>{item.product.name}</h3>
+                  <p>{item.product.description}</p>
+                  <span className="cart-meta">{item.product.category}</span>
+                </div>
+                <div className="cart-actions">
+                  <label htmlFor={`quantity-${item.product.id}`}>Cantidad</label>
+                  <input
+                    id={`quantity-${item.product.id}`}
+                    type="number"
+                    min="0"
+                    value={item.quantity}
+                    onChange={(event) =>
+                      updateQuantity(item.product.id, Number(event.target.value))
+                    }
+                  />
+                  <span className="cart-price">
+                    ${(item.product.price * item.quantity).toFixed(2)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <footer className="cart-summary">
+            <div>
+              <p>Total estimado</p>
+              <strong>${orderTotal.toFixed(2)}</strong>
+            </div>
+            <div className="cart-buttons">
+              <button type="button" className="secondary" onClick={clearCart}>
+                Vaciar carrito
+              </button>
+              <a
+                className="primary"
+                href={`https://wa.me/51999999999?text=${whatsappMessage}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Enviar por WhatsApp
+              </a>
+            </div>
+          </footer>
+        </>
+      )}
+    </section>
+  )
+}
+
+function Contact() {
+  return (
+    <section className="contact-view">
+      <header>
+        <h2>Contacto comercial</h2>
+        <p>
+          Cuéntanos qué necesitas y nuestro equipo de ventas preparará la cotización más
+          conveniente.
+        </p>
+      </header>
+      <div className="contact-grid">
+        <form className="contact-form">
+          <label htmlFor="contact-name">Nombre y empresa</label>
+          <input id="contact-name" type="text" placeholder="Ingresa tus datos" />
+
+          <label htmlFor="contact-email">Correo electrónico</label>
+          <input id="contact-email" type="email" placeholder="tucorreo@empresa.com" />
+
+          <label htmlFor="contact-phone">Teléfono</label>
+          <input id="contact-phone" type="tel" placeholder="999 999 999" />
+
+          <label htmlFor="contact-message">Detalle de la solicitud</label>
+          <textarea
+            id="contact-message"
+            rows="4"
+            placeholder="Incluye cantidades, marcas o plazos aproximados"
+          />
+
+          <button type="submit">Solicitar cotización</button>
+        </form>
+        <aside className="contact-info">
+          <h3>También puedes visitarnos</h3>
+          <p>
+            Av. Principal 123, Lima. <br />
+            Lunes a sábado de 8:00 a 18:00.
+          </p>
+          <h3>Atención inmediata</h3>
+          <ul>
+            <li>Central telefónica: (01) 555-8899</li>
+            <li>Ventas corporativas: ventas@losgigantes.pe</li>
+            <li>Servicio técnico: soporte@losgigantes.pe</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+function Footer({ setActiveView }) {
+  return (
+    <footer className="site-footer">
+      <div className="footer-main">
+        <div className="footer-column">
+          <div className="footer-brand">
+            <img
+              src="https://losgigantes.sistinfo.com/empresa/imagenes/brand_logo.png"
+              alt="Logo de Los Gigantes"
+            />
+            <span className="footer-tagline">Soluciones ferreteras profesionales</span>
+          </div>
+          <p>
+            Soluciones integrales para construcción, minería e industria. Acompañamos tus
+            proyectos con asesoría técnica y logística confiable.
+          </p>
+        </div>
+        <div className="footer-column">
+          <h3>Enlaces</h3>
+          <ul>
+            {Object.entries(views).map(([key, label]) => (
+              <li key={key}>
+                <button type="button" onClick={() => setActiveView(key)}>
+                  {label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="footer-column">
+          <h3>Contacto</h3>
+          <ul>
+            <li>Av. Principal 123, Lima</li>
+            <li>
+              <a href="tel:+5115558899">(01) 555-8899</a>
+            </li>
+            <li>
+              <a href="mailto:ventas@losgigantes.pe">ventas@losgigantes.pe</a>
+            </li>
+            <li>Lunes a sábado de 8:00 a 18:00</li>
+          </ul>
+        </div>
+        <div className="footer-column">
+          <h3>Newsletter</h3>
+          <p>Recibe novedades, lanzamientos y promociones especiales.</p>
+          <form className="footer-form">
+            <input type="email" placeholder="tu correo" aria-label="Correo electrónico" />
+            <button type="submit">Suscribirme</button>
+          </form>
+        </div>
+      </div>
+      <div className="footer-bottom">
+        <p>© {new Date().getFullYear()} Los Gigantes Compañía Ferretera. Todos los derechos reservados.</p>
+        <div className="footer-socials">
+          <a href="https://www.facebook.com" target="_blank" rel="noreferrer">
+            Facebook
+          </a>
+          <a href="https://www.instagram.com" target="_blank" rel="noreferrer">
+            Instagram
+          </a>
+          <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">
+            LinkedIn
+          </a>
+        </div>
+      </div>
+    </footer>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,10 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont,
+    'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0b1739;
+  background-color: #e6f0ff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -14,55 +12,29 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  text-decoration: none;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background: #e6f0ff;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+input,
+textarea {
+  font-family: inherit;
+}
+
+* {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- collapse the primary navigation into a hamburger panel on phones so only the brand mark and toggle remain visible by default
- add mobile backdrop handling and a shared view-change helper so the menu closes after navigating or adding items to the cart
- refresh header spacing rules to support the new overlay layout and tweak mobile top-bar typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e407f375708320a8085e83577da2e2